### PR TITLE
Fixed "phantom" first vision

### DIFF
--- a/coder.hy
+++ b/coder.hy
@@ -6,7 +6,8 @@
         [watchdog.events [FileSystemEventHandler]]
         [lib.runner [Runner]]
         [config [OSC_EYE]]
-        [lib.osc [Osc]])
+        [lib.osc [Osc]]
+        os)
 
 
 (defn getCode [filename]
@@ -30,7 +31,7 @@
       (.sender self.osc OSC_EYE)
 
       (for [filename (glob "visions/*.py")]
-          (.send self.osc "/eye/code" [filename (getCode filename)] OSC_EYE))
+          (.send self.osc "/eye/code" [(.join os.path (.getcwd os) filename) (getCode filename)] OSC_EYE))
 
       (setv handler (Handler self.osc))
       (setv self.observer (Observer))


### PR DESCRIPTION
The problem was that the first vision was created with a local path, while the second one with a full path (passed by watchdog), so it was inserted twice and only the second was updated when the file changed.